### PR TITLE
fix "Error: Extra data:" error

### DIFF
--- a/onepassword/keychain.py
+++ b/onepassword/keychain.py
@@ -114,7 +114,7 @@ class KeychainItem(object):
         )
         encrypted_json = self._lazily_load("_encrypted_json")
         decrypted_json = key.decrypt(self._encrypted_json)
-        self._data = json.loads(decrypted_json)
+        self._data = json.loads(decrypted_json.replace('\x10',''))
         self.password = self._find_password()
 
     def _find_password(self):


### PR DESCRIPTION
When using 1Password 4, it seems that I get this error on some entries:

```
1pass: Error: Extra data: line 1 column 800 - line 1 column 816 (char 800 - 816)
```

I tracked it down to there be extra non-printing characters at the end of the decrypted json data.  This change fixed it for me.
