### PR TITLE
Add a specific check for keychain path not existing

### DIFF
--- a/onepassword/keychain.py
+++ b/onepassword/keychain.py
@@ -60,6 +60,8 @@ class Keychain(object):
 
     def _load_encryption_keys(self):
         path = os.path.join(self._path, "data", "default", "encryptionKeys.js")
+        if not os.path.exists(path):
+            raise Exception('No KeyChain could be found at: {}'.format(self._path))
         with open(path, "r") as f:
             key_data = json.load(f)
 


### PR DESCRIPTION
Raising a specific exception when the Keychain path doesn't exist to make sure an error is shown to the user where it currently returns an empty message.
