### PR TITLE
Remove trailing backspace characters from json.

### DIFF
--- a/onepassword/keychain.py
+++ b/onepassword/keychain.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import functools
 from fuzzywuzzy import process
 
@@ -121,7 +122,10 @@ class KeychainItem(object):
         if isinstance(decrypted_json, bytes):
             decrypted_json = decrypted_json.decode('utf-8')
 
+        # Remove trailing backspace characters from json
+        decrypted_json = re.sub('\x08*$', '', decrypted_json)
         self._data = json.loads(decrypted_json)
+
         self.password = self._find_password()
 
     def _find_password(self):


### PR DESCRIPTION
Some of my 1password vault entries have multiple trailing backspace characters - `\x08` - and so the json decode is failing with the following exception:

```
In [5]:     login = settings.KEYCHAIN.item('Foo')
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
<ipython-input-5-0ed739f971ec> in <module>()
----> 1 login = settings.KEYCHAIN.item('Foo')

/usr/local/lib/python3.6/site-packages/onepassword/keychain.py in item(self, name, fuzzy_threshold)
     37             exact_name = match[0]
     38             item = self._items[exact_name]
---> 39             item.decrypt_with(self)
     40             return item
     41         else:

/usr/local/lib/python3.6/site-packages/onepassword/keychain.py in decrypt_with(self, keychain)
    122             decrypted_json = decrypted_json.decode('utf-8')
    123
--> 124         self._data = json.loads(decrypted_json)
    125         self.password = self._find_password()
    126

/usr/local/Cellar/python3/3.6.0_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py in loads(s, encoding, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    352             parse_int is None and parse_float is None and
    353             parse_constant is None and object_pairs_hook is None and not kw):
--> 354         return _default_decoder.decode(s)
    355     if cls is None:
    356         cls = JSONDecoder

/usr/local/Cellar/python3/3.6.0_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py in decode(self, s, _w)
    340         end = _w(s, end).end()
    341         if end != len(s):
--> 342             raise JSONDecodeError("Extra data", s, end)
    343         return obj
    344

JSONDecodeError: Extra data: line 1 column 617 (char 616)
```

Here's an example output from the debugger when trying to load one of these entries:
```
ipdb> decrypted_json = key.decrypt(self._encrypted_json)
ipdb> print(decrypted_json)
b'{"fields":[{"value":"********","name":"password","type":"P"},{"value":"","name":"username","type":"T"},{"value":"Foo","id":"employer;opid=__0","name":"employer","type":"T"},{"value":"foo@example.org","id":"email;opid=__1","name":"email","type":"E","designation":"username"},{"value":"********","id":"password;opid=__2","name":"password","type":"P","designation":"password"},{"value":"","id":";opid=__3","name":"","type":"I"}],"htmlMethod":"LB1","notesPlain":"foo","URLs":[{"url":"https:\\/\\/my.foo.org"},{"label":"","url":"https:\\/\\/example.org"}]}\x08\x08\x08\x08\x08\x08\x08\x08'
ipdb> decrypted_json = decrypted_json.decode('utf-8')
ipdb> print(decrypted_json)
{"fields":[{"value":"********","name":"password","type":"P"},{"value":"","name":"username","type":"T"},{"value":"Foo","id":"employer;opid=__0","name":"employer","type":"T"},{"value":"foo@example.org","id":"email;opid=__1","name":"email","type":"E","designation":"username"},{"value":"********","id":"password;opid=__2","name":"password","type":"P","designation":"password"},{"value":"","id":";opid=__3","name":"","type":"I"}],"htmlMethod":"LB1","notesPlain":"foo","URLs":[{"url":"https:\/\/my.foo.org"},{"label":"","url":"https:\/\/example.org"}]}
```

This patch takes the naive approach of clearing out the backspace characters before decoding the json. I am guessing the 1password format isn't clearly documented, so we can't really know where these characters are coming from, but suggestions welcome if someone understands the format better than I do.